### PR TITLE
Remove argparse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ pygments = "^2.14.0"
 ordered-set = "^4.1.0"
 dotwiz = "^0.4.0"
 mmh3 = "^3.0.0"
-argparse = "^1.4.0"
 regex = "^2023.3.23"
 
 


### PR DESCRIPTION
Default module in Python >= 3.2
https://docs.python.org/3/library/argparse.html